### PR TITLE
Fix double calls to MPI_INIT() and MPI_FINALIZE()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ if(USE_MPI)
     set(CMAKE_Fortran_COMPILER "${MPI_Fortran_COMPILER}")
     set(CMAKE_C_COMPILER "${MPI_C_COMPILER}")
     set(CMAKE_CXX_COMPILER "${MPI_CXX_COMPILER}")
-    set(FFLAGS2 ${FFLAGS2} -DMPI)
+    set(FFLAGS2 ${FFLAGS2} -DMPI -DHAVE_MPI_MOD)
     if(BUILD_DEBUG)
         set(FFLAGS2 ${FFLAGS2} -DDEBUG_MPI)
     endif(BUILD_DEBUG)
@@ -82,6 +82,8 @@ message("DGSWEM_INC_DIR=${DGSWEM_INC_DIR}")
 # Link
 include_directories(${DGSWEM_INC_DIR})
 link_directories(${DGSWEM_LIB_DIR})
+
+set(CMAKE_Fortran_FLAGS ${CMAKE_Fortran_FLAGS} -fvisibility=hidden )
 
 #------------------------------------------------------------------------------#
 # Targets

--- a/src/adcircdgswem_main.F90
+++ b/src/adcircdgswem_main.F90
@@ -14,6 +14,9 @@ module ADCouplerMain
     use adcirc_export, only: adcirc_init, adcirc_run, adcirc_final
     use dgswem_mod, only: dgswem_init, dgswem_run, dgswem_fin
 
+#ifdef HAVE_MPI_MOD
+    use mpi, only: MPI_COMM_WORLD
+#endif
     implicit none
 
 
@@ -39,12 +42,14 @@ contains
     !--------------------------------------------------------------------------!
     subroutine adcoupler_initialize()
         ! Initialize function of the ADCIRC DG-SWEM coupler.
+#ifndef HAVE_MPI_MOD
+        include 'mpif.h'
+#endif
+        ! Call DGSWEM's init function.
+        call dgswem_init()
 
         ! Call ADCIRC's init function.
-        call adcirc_init
-
-        ! Call DGSWEM's init function.
-        call dgswem_init
+        call adcirc_init(MPI_COMM_WORLD)
 
     end subroutine
 
@@ -67,12 +72,13 @@ contains
     !--------------------------------------------------------------------------!
     subroutine adcoupler_finalize()
         ! Finalize function of the ADCIRC DG-SWEM coupler.
+        logical :: no_mpi_finalize_adcirc = .true.
+
+        ! Call ADCIRC's finalize function, but don't actually call mpi_finalize!
+        call adcirc_final(no_mpi_finalize_adcirc)
 
         ! Call DGSWEM's finalize function.
         call dgswem_fin
-
-        ! Call ADCIRC's finalize function.
-        call adcirc_final
 
     end subroutine
 


### PR DESCRIPTION
ADCIRC and DGSWEM both call MPI_INIT() and MPI_FINALIZE(). However,
ADCIRC's call is optional based on arguments passed to its
initialize and finalize routines, whereas DGSWEM's calls to the
aforementioned MPI functions are compulsory. Therefore, through this
commit, we let DGSWEM initialize first and finalize second to
circumvent these double calls.